### PR TITLE
fix(index): 首页过渡动画样式调整

### DIFF
--- a/source/css/_index.scss
+++ b/source/css/_index.scss
@@ -32,7 +32,6 @@
       .post-content {
         color: #a3a3a3;
         margin-bottom: 8px;
-        transition: $transition;
         * {
           margin: 0;
           padding: 0;

--- a/source/style.scss
+++ b/source/style.scss
@@ -1,5 +1,5 @@
 $hover-color: #007fff;
-$transition: .3s all;
+$transition: .3s color;
 $box-shadow: 0 2px 5px -2px rgba(0,0,0,.05);
 $breakpoint-desktop: 1032px;
 $breakpoint-phone: 700px;


### PR DESCRIPTION
在 Chrome 浏览器中，首页刷新时触发 translation 动画会产生非预期效果。被设置 translation 属性的标签会产生一个标签默认值到设定值的动画，Safari 中无此效果。